### PR TITLE
03.22 fixes

### DIFF
--- a/20240930_codextended/maps/mp/gametypes/_weapons.gsc
+++ b/20240930_codextended/maps/mp/gametypes/_weapons.gsc
@@ -342,7 +342,7 @@ precacheWeapons()
 		precacheItem("enfield_mp");
 		//precacheItem("m1garand_mp");
 		//precacheItem("enfield_scope_mp");
-		precacheitem("springfield_mp");
+		precacheItem("springfield_mp");
 		//precacheItem("shotgun_mp");
 		precacheItem("thompson_mp");
 		precacheItem("bren_mp");
@@ -447,39 +447,40 @@ defineWeapons()
 	switch(game["allies"])
 	{
 	case "american":
-		//addWeapon("greasegun_mp", 		"smg", 			"allies", 	"scr_allow_greasegun", 		"ui_allow_greasegun");
+		//addWeapon("greasegun_mp", 	"smg", 				"allies", 	"scr_allow_greasegun", 		"ui_allow_greasegun");
 		addWeapon("m1carbine_mp", 		"semiautomatic",	"allies", 	"scr_allow_m1carbine",		"ui_allow_m1carbine");
 		addWeapon("m1garand_mp", 		"semiautomatic", 	"allies", 	"scr_allow_m1garand", 		"ui_allow_m1garand");
-		addWeapon("springfield_mp", 		"sniper", 		"allies", 	"scr_allow_springfield", 	"ui_allow_springfield");
-		addWeapon("thompson_mp", 		"smg", 			"allies", 	"scr_allow_thompson", 		"ui_allow_thompson");
-		addWeapon("bar_mp", 			"mg", 			"allies", 	"scr_allow_bar", 		"ui_allow_bar");
+		addWeapon("springfield_mp", 	"sniper", 			"allies", 	"scr_allow_springfield", 	"ui_allow_springfield");
+		addWeapon("thompson_mp", 		"smg", 				"allies", 	"scr_allow_thompson", 		"ui_allow_thompson");
+		addWeapon("bar_mp", 			"mg", 				"allies", 	"scr_allow_bar", 			"ui_allow_bar");
 		break;
 
 	case "british":
-		addWeapon("sten_mp", 			"smg", 			"allies", 	"scr_allow_sten", 		"ui_allow_sten");
-		addWeapon("enfield_mp", 		"boltaction", 		"allies", 	"scr_allow_enfield", 		"ui_allow_enfield");
-		addWeapon("m1garand_mp", 		"semiautomatic", 	"allies", 	"scr_allow_m1garand", 		"ui_allow_m1garand");
-		addWeapon("enfield_scope_mp", 		"sniper",		"allies", 	"scr_allow_enfieldsniper", 	"ui_allow_enfieldsniper");
-		addWeapon("thompson_mp", 		"smg", 			"allies", 	"scr_allow_thompson", 		"ui_allow_thompson");
-		addWeapon("bren_mp", 			"mg", 			"allies", 	"scr_allow_bren", 		"ui_allow_bren");
+		addWeapon("sten_mp", 				"smg", 				"allies", 	"scr_allow_sten", 			"ui_allow_sten");
+		addWeapon("enfield_mp", 			"boltaction", 		"allies", 	"scr_allow_enfield", 		"ui_allow_enfield");
+		//addWeapon("m1garand_mp", 			"semiautomatic", 	"allies", 	"scr_allow_m1garand", 		"ui_allow_m1garand");
+		//addWeapon("enfield_scope_mp", 	"sniper",			"allies", 	"scr_allow_enfieldsniper", 	"ui_allow_enfieldsniper");
+		addWeapon("springfield_mp", 		"sniper",			"allies", 	"scr_allow_springfield", 	"ui_allow_springfield");
+		//addWeapon("thompson_mp", 			"smg", 				"allies", 	"scr_allow_thompson", 		"ui_allow_thompson");
+		addWeapon("bren_mp", 				"mg", 				"allies", 	"scr_allow_bren", 			"ui_allow_bren");
 		break;
 
 	case "russian":
-		//addWeapon("PPS42_mp", 			"smg", 			"allies", 	"scr_allow_pps42", 		"ui_allow_pps42");
+		//addWeapon("PPS42_mp", 			"smg", 				"allies", 	"scr_allow_pps42", 			"ui_allow_pps42");
 		addWeapon("mosin_nagant_mp", 		"boltaction", 		"allies", 	"scr_allow_nagant", 		"ui_allow_nagant");
-		//addWeapon("SVT40_mp", 			"semiautomatic", 	"allies", 	"scr_allow_svt40", 		"ui_allow_svt40");
-		addWeapon("mosin_nagant_sniper_mp", 	"sniper", 		"allies", 	"scr_allow_nagantsniper", 	"ui_allow_nagantsniper");
-		addWeapon("ppsh_mp", 			"smg", 			"allies", 	"scr_allow_ppsh", 		"ui_allow_ppsh"); //PPSH_CHANGE
-		//addWeapon("vpo135_mp", 			"smg", 			"allies", 	"scr_allow_ppsh", 		"ui_allow_ppsh");
+		//addWeapon("SVT40_mp", 			"semiautomatic", 	"allies", 	"scr_allow_svt40", 			"ui_allow_svt40");
+		addWeapon("mosin_nagant_sniper_mp", "sniper", 			"allies", 	"scr_allow_nagantsniper", 	"ui_allow_nagantsniper");
+		addWeapon("ppsh_mp", 				"smg", 				"allies", 	"scr_allow_ppsh", 			"ui_allow_ppsh"); //PPSH_CHANGE
+		//addWeapon("vpo135_mp", 			"smg", 				"allies", 	"scr_allow_ppsh", 			"ui_allow_ppsh");
 		break;
 	}
 
 	// Germans
-	addWeapon("mp40_mp", 			"smg", 			"axis", 	"scr_allow_mp40", 		"ui_allow_mp40");
+	addWeapon("mp40_mp", 			"smg", 				"axis", 	"scr_allow_mp40", 			"ui_allow_mp40");
 	addWeapon("kar98k_mp", 			"boltaction", 		"axis", 	"scr_allow_kar98k", 		"ui_allow_kar98k");
-	//addWeapon("g43_mp", 			"semiautomatic", 	"axis", 	"scr_allow_g43", 		"ui_allow_g43");
-	addWeapon("kar98k_sniper_mp", 		"sniper", 		"axis", 	"scr_allow_kar98ksniper", 	"ui_allow_kar98ksniper");
-	addWeapon("mp44_mp", 			"mg", 			"axis", 	"scr_allow_mp44", 		"ui_allow_mp44");
+	//addWeapon("g43_mp", 			"semiautomatic", 	"axis", 	"scr_allow_g43", 			"ui_allow_g43");
+	addWeapon("kar98k_sniper_mp", 	"sniper", 			"axis", 	"scr_allow_kar98ksniper", 	"ui_allow_kar98ksniper");
+	addWeapon("mp44_mp", 			"mg", 				"axis", 	"scr_allow_mp44", 			"ui_allow_mp44");
 
 	// All teams
 	//addWeapon("shotgun_mp", 		"shotgun", 		"both", 	"scr_allow_shotgun", 		"ui_allow_shotgun");

--- a/20240930_codextended/maps/mp/gametypes/rules/sd/comp.gsc
+++ b/20240930_codextended/maps/mp/gametypes/rules/sd/comp.gsc
@@ -138,7 +138,7 @@ GetCvars(arr)
 	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_rifle_mode", 0);
 
 	// Nade spawn counts for each class
-	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_boltaction_nades", 1);
+	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_boltaction_nades", 2);
 	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_semiautomatic_nades", 1);
 	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_smg_nades", 1);
 	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_sniper_nades", 1);
@@ -200,6 +200,7 @@ GetCvars(arr)
 	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_allow_kar98ksniper", 1);
 	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_allow_mp44", 1);
 	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_allow_shotgun", 1);
+	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_allow_fg42", 0);
 
 	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_allow_pistols", 1);
 	arr = maps\mp\gametypes\global\_global::ruleCvarDefault(arr, "scr_allow_turrets", 1);

--- a/20240930_codextended/ui_mp/macros.h
+++ b/20240930_codextended/ui_mp/macros.h
@@ -127,7 +127,7 @@ itemDef \
 	visible			1 \
 	rect			0 0 w 24 \
 	origin			x 438 \
-	forecolor		1 1 1 0.2 \
+	forecolor		1 1 1 1 \
 	type			ITEM_TYPE_BUTTON \
 	text			textstring \
 	textfont		UI_FONT_NORMAL \
@@ -173,7 +173,7 @@ itemDef \
 itemDef \
 { \
 	style			WINDOW_STYLE_SHADER \
-	rect			-128 0 896 480 \
+	rect			-128 0 896 480 HORIZONTAL_ALIGN_FULLSCREEN VERTICAL_ALIGN_FULLSCREEN \
 	background		"gradient" \
 	visible			1 \
 	decoration \
@@ -368,11 +368,11 @@ itemDef \
 	visible			1 \
 	rect			0 0 128 24 \
 	origin			originpos \
-	forecolor		1 1 1 0.2 \
+	forecolor		1 1 1 1 \
 	type			ITEM_TYPE_BUTTON \
 	text			stringtext \
 	textfont		UI_FONT_NORMAL \
-	textscale		1 /*GLOBAL_TEXT_SIZE*/ \
+	textscale		0.24 /*GLOBAL_TEXT_SIZE*/ \
 	textstyle		ITEM_TEXTSTYLE_SHADOWED \
 	textaligny		20 \
 	cvartest		cvartext \
@@ -395,11 +395,11 @@ itemDef  \
 	visible			1 \
 	rect			0 0 128 24 \
 	origin			originpos \
-	forecolor		1.0 1.0 0.0 1.0 /*GLOBAL_DISABLED_COLOR*/ \
+	forecolor		1 1 1 0.2 \
 	type			ITEM_TYPE_BUTTON \
 	text			"" \
 	textfont		UI_FONT_NORMAL \
-	textscale		1 /*GLOBAL_TEXT_SIZE*/ \
+	textscale		0.24 /*GLOBAL_TEXT_SIZE*/ \
 	textstyle		ITEM_TEXTSTYLE_SHADOWED \
 	textaligny		20 \
 	cvartest		cvartext \
@@ -420,7 +420,7 @@ itemDef  \
 	type			ITEM_TYPE_BUTTON \
 	text			stringtext \
 	textfont		UI_FONT_NORMAL \
-	textscale		1 /*GLOBAL_TEXT_SIZE*/ \
+	textscale		0.24 /*GLOBAL_TEXT_SIZE*/ \
 	textstyle		ITEM_TEXTSTYLE_SHADOWED \
 	textaligny		20 \
 	cvartest		cvartext \
@@ -438,7 +438,7 @@ itemDef  \
 	type			ITEM_TYPE_BUTTON \
 	text			stringtext \
 	textfont		UI_FONT_NORMAL \
-	textscale		1 /*GLOBAL_TEXT_SIZE*/ \
+	textscale		0.24 /*GLOBAL_TEXT_SIZE*/ \
 	textstyle		ITEM_TEXTSTYLE_SHADOWED \
 	textaligny		20 \
 	cvartest		cvartext \
@@ -463,17 +463,17 @@ itemDef \
 	rect			0 0 224 112 \
 	origin			ORIGIN_WEAPONIMAGE \
 	style			WINDOW_STYLE_SHADER \
-	background		weaponimage \
+	background		"ui_mp/assets/hud@" weaponimage ".tga" \
 	decoration \
 } \
 itemDef \
 { \
 	name			weaponimage \
 	visible 		0 \
-	rect			0 0 32 32 \
+	rect			0 0 0 0 \
 	origin			ORIGIN_GRENADESLOT1 \
 	style			WINDOW_STYLE_SHADER \
-	background		"gfx/icons/hud@" grenadeimage ".tga" \
+	background		"ui_mp/assets/hud@" grenadeimage ".tga" \
 	decoration \
 } \
 itemDef  \
@@ -481,7 +481,7 @@ itemDef  \
 	name			weaponimage \
 	visible			0 \
 	origin			ORIGIN_USEDBY \
-	forecolor		1 1 1 0.2 \
+	forecolor		1 1 1 1 \
 	text 			"Used by:" \
 	type			ITEM_TYPE_TEXT \
 	textfont		UI_FONT_NORMAL \
@@ -489,7 +489,7 @@ itemDef  \
 	textstyle		ITEM_TEXTSTYLE_SHADOWED \
 	textalign		ITEM_ALIGN_LEFT \
 	cvartest		"ui_weapons_usedby_" weaponname \
-	hidecvar		{ "" } \
+	hideCvar		{ "" } \
 	decoration \
 } \
 itemDef  \
@@ -497,16 +497,16 @@ itemDef  \
 	name			weaponimage \
 	visible			0 \
 	origin			ORIGIN_USEDBY2 \
-	forecolor		1 1 1 0.2 \
+	forecolor		1 1 1 1 \
 	text 			" " \
 	type			ITEM_TYPE_EDITFIELD \
 	textfont		UI_FONT_NORMAL \
 	textscale		0.25 \
 	textstyle		ITEM_TEXTSTYLE_SHADOWED \
 	textalign		ITEM_ALIGN_LEFT \
-	cvar			"ui_weapons_usedby_" weaponname  \
-	cvartest		"ui_weapons_usedby_" weaponname  \
-	hidecvar		{ "" } \
+	cvar			"ui_weapons_usedby_" weaponname \
+	cvartest		"ui_weapons_usedby_" weaponname \
+	hideCvar		{ "" } \
 	decoration \
 }
 
@@ -538,7 +538,7 @@ itemDef \
 	visible			1 \
 	rect			0 0 180 110 \
 	origin			170 180 \
-	forecolor		1 1 1 0.2 \
+	forecolor		1 1 1 1 \
 	cvar			"ui_serverinfo_left1" \
 	textfont		UI_FONT_NORMAL \
 	textscale		0.3 \
@@ -552,7 +552,7 @@ itemDef  \
 	visible			1 \
 	rect			0 0 128 110 \
 	origin			185 180 \
-	forecolor		1 1 1 0.2 \
+	forecolor		1 1 1 1 \
 	cvar			"ui_serverinfo_left2" \
 	textfont		UI_FONT_NORMAL \
 	textscale		0.3 \
@@ -566,7 +566,7 @@ itemDef \
 	visible			1 \
 	rect			0 0 180 110 \
 	origin			390 180 \
-	forecolor		1 1 1 0.2 \
+	forecolor		1 1 1 1 \
 	cvar			"ui_serverinfo_right1" \
 	textfont		UI_FONT_NORMAL \
 	textscale		0.3 \

--- a/20240930_codextended/ui_mp/scriptmenus/ingame.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/ingame.menu
@@ -11,6 +11,7 @@
 		//blurWorld		5.0
 		onOpen
 		{
+			exec "set cg_drawstatus 0";
 			//close matchinfo;
 			//close ingame_scoreboard_sd;
 
@@ -29,10 +30,12 @@
 		{
 			CLOSE_SUBMENUS;
 			close matchinfo;
+			exec "set cg_drawstatus 1";
 		}
 		onEsc
 		{
 			close ingame;
+			exec "set cg_drawstatus 1";
 		}
 
 

--- a/20240930_codextended/ui_mp/scriptmenus/serverinfo_sd.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/serverinfo_sd.menu
@@ -12,6 +12,7 @@
 		//blurWorld		5.0
 		onOpen 
 		{
+			exec "set cg_drawstatus 0";
 			//scriptMenuResponse "open";
 			open serverinfo_sd_keys;
 
@@ -21,6 +22,7 @@
 		onClose
 		{
 			scriptMenuResponse "close";
+			exec "set cg_drawstatus 1";
 		}
 
 		// Background

--- a/20240930_codextended/ui_mp/scriptmenus/team_americangerman.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/team_americangerman.menu
@@ -40,9 +40,9 @@
 		ITEM_TEXT_HEADING("@MPMENU_TEAM")
 
 
-		// Bottom: 1. Russian
-		ITEM_BUTTON_ONCVAR		(ORIGIN_CHOICE1, "@MPMENU_1_RUSSIAN", "ui_allow_joinallies", showCvar{"1"}, ; show "allies_info", scriptMenuResponse "allies" ; close team_americangerman;)
-		ITEM_BUTTON_ONCVAR_DISABLED	(ORIGIN_CHOICE1, "@MPMENU_1_RUSSIAN", "ui_allow_joinallies", showCvar{"2"}, ;)
+		// Bottom: 1. American
+		ITEM_BUTTON_ONCVAR		(ORIGIN_CHOICE1, "@MPMENU_1_AMERICAN", "ui_allow_joinallies", showCvar{"1"}, ; show "allies_info", scriptMenuResponse "allies" ; close team_americangerman;)
+		ITEM_BUTTON_ONCVAR_DISABLED	(ORIGIN_CHOICE1, "@MPMENU_1_AMERICAN", "ui_allow_joinallies", showCvar{"2"}, ;)
 
 		// Bottom: 2. German
 		ITEM_BUTTON_ONCVAR		(ORIGIN_CHOICE2, "@MPMENU_2_GERMAN", "ui_allow_joinaxis", showCvar{"1"}, ; show "axis_info", scriptMenuResponse "axis" ; close team_americangerman;)

--- a/20240930_codextended/ui_mp/scriptmenus/team_americangerman.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/team_americangerman.menu
@@ -11,8 +11,10 @@
 		//blurWorld		5.0
 		onOpen
 		{
+			exec "set cg_drawstatus 0";
 			CLOSE_SUBMENUS;
 			open team_americangerman_keys;
+			
 
 			// Make sure cursor is enable (in case of spectator menu fails)
 			setDvar cl_bypassMouseInput "0" // enable cursor movement
@@ -22,10 +24,12 @@
 		{
 			CLOSE_SUBMENUS;
 			close matchinfo;
+			exec "set cg_drawstatus 1";
 		}
 		onEsc
 		{
 			close team_americangerman;
+			exec "set cg_drawstatus 1";
 		}
 
 

--- a/20240930_codextended/ui_mp/scriptmenus/team_britishgerman.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/team_britishgerman.menu
@@ -12,6 +12,7 @@
 		onOpen
 		{
 			CLOSE_SUBMENUS;
+			exec "set cg_drawstatus 0";
 			open team_britishgerman_keys;
 
 			// Make sure cursor is enable (in case of spectator menu fails)
@@ -22,10 +23,12 @@
 		{
 			CLOSE_SUBMENUS;
 			close matchinfo;
+			exec "set cg_drawstatus 1";
 		}
 		onEsc
 		{
 			close team_britishgerman;
+			exec "set cg_drawstatus 1";
 		}
 
 

--- a/20240930_codextended/ui_mp/scriptmenus/team_russiangerman.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/team_russiangerman.menu
@@ -12,6 +12,7 @@
 		onOpen
 		{
 			CLOSE_SUBMENUS;
+			exec "set cg_drawstatus 0";
 			open team_russiangerman_keys;
 
 			// Make sure cursor is enable (in case of spectator menu fails)
@@ -22,10 +23,12 @@
 		{
 			CLOSE_SUBMENUS;
 			close matchinfo;
+			exec "set cg_drawstatus 1";
 		}
 		onEsc
 		{
 			close team_russiangerman;
+			exec "set cg_drawstatus 1";
 		}
 
 

--- a/20240930_codextended/ui_mp/scriptmenus/weapon_american.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/weapon_american.menu
@@ -15,6 +15,7 @@
 		onOpen
 		{
 			CLOSE_SUBMENUS;
+			exec "set cg_drawstatus 0";
 			open weapon_american_keys;
 
 			// Make sure cursor is enable (in case of spectator menu fails)
@@ -25,6 +26,7 @@
 		{
 			CLOSE_SUBMENUS;
 			close matchinfo;
+			exec "set cg_drawstatus 1";
 		}
 		onEsc
 		{
@@ -32,6 +34,7 @@
 			close weapon_american;
 			close matchinfo;
 			close weapon_american_keys;
+			exec "set cg_drawstatus 1";
 		}
 
 

--- a/20240930_codextended/ui_mp/scriptmenus/weapon_american.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/weapon_american.menu
@@ -1,0 +1,85 @@
+#include "ui_mp/menudef.h"
+#include "ui_mp/macros.h"
+
+#define HIDE_ALL hide m1carbine; hide m1garand; hide thompson; hide bar; hide springfield;
+
+
+{
+	menuDef
+	{
+		name			"weapon_american"
+		rect			0 0 640 480
+		focuscolor		1 1 1 1
+		style			WINDOW_STYLE_EMPTY
+		//blurWorld		5.0
+		onOpen
+		{
+			CLOSE_SUBMENUS;
+			open weapon_american_keys;
+
+			// Make sure cursor is enable (in case of spectator menu fails)
+			setDvar cl_bypassMouseInput "0" // enable cursor movement
+
+		}
+		onClose
+		{
+			CLOSE_SUBMENUS;
+			close matchinfo;
+		}
+		onEsc
+		{
+			HIDE_ALL
+			close weapon_american;
+			close matchinfo;
+			close weapon_american_keys;
+		}
+
+
+		// Background
+		DRAW_MAP_BACKGROUND_IF_BLACKOUT
+		DRAW_BLUISH_BACKGROUND
+		DRAW_GRADIENT_LEFT_TO_RIGHT
+		DRAW_BARS
+
+		// Header
+		ITEM_TEXT_HEADING("@MPMENU_WEAPON")
+
+
+		// MENU CHOICES
+		ITEM_WEAPON(ORIGIN_CHOICE1, "button_m1carbine", "m1carbine_mp", "@MPMENU_1_M1A1_CARBINE", "ui_allow_m1carbine", "m1carbine", show m1carbine;, scriptMenuResponse "m1carbine_mp", grenadeimage, "semiautomatic";)
+
+		ITEM_WEAPON(ORIGIN_CHOICE2, "button_m1garand", "m1garand_mp", "@MPMENU_2_M1_GARAND", "ui_allow_m1garand", "m1garand" , show m1garand;, scriptMenuResponse "m1garand_mp", grenadeimage, "semiautomatic")
+
+		ITEM_WEAPON(ORIGIN_CHOICE3, "button_thompson", "thompson_mp", "@MPMENU_3_THOMPSON", "ui_allow_thompson", "thompson" , show thompson;, scriptMenuResponse "thompson_mp", grenadeimage, "smg")
+
+		ITEM_WEAPON(ORIGIN_CHOICE4, "button_bar", "bar_mp", "@MPMENU_4_BAR", "ui_allow_bar", "bar" , show bar;, scriptMenuResponse "bar_mp", grenadeimage, "mg")
+
+		ITEM_WEAPON(ORIGIN_CHOICE5, "button_springfield", "springfield_mp", "@MPMENU_5_SPRINGFIELD", "ui_allow_springfield", "springfield", show springfield;, scriptMenuResponse "springfield_mp", grenadeimage, "sniper")
+
+
+
+		// Close
+		ITEM_BAR_BOTTOM_BUTTON("^9[ESC]^7 Close",	40, 70, close weapon_american;)
+		// Main menu
+		ITEM_BAR_BOTTOM_BUTTON("^9[SPACE]^7 Main Menu",	135, 120, close weapon_american; open main;)
+	}
+
+
+	// Key choices has to be in different menu if we are using submenus
+	// This keys is opened as last and will be in focus - so keys from this submenu will be accepted
+	menuDef
+	{
+		name			"weapon_american_keys"
+		rect			0 0 1 1
+		focuscolor		GLOBAL_FOCUSED_COLOR
+		style			WINDOW_STYLE_EMPTY
+
+		execKey "1" { play "mouse_click"; scriptMenuResponse "m1carbine_mp" ; close weapon_american; }
+		execKey "2" { play "mouse_click"; scriptMenuResponse "m1garand_mp" ; close weapon_american; }
+		execKey "3" { play "mouse_click"; scriptMenuResponse "thompson_mp" ; close weapon_american; }
+		execKey "4" { play "mouse_click"; scriptMenuResponse "bar_mp" ; close weapon_american; }
+		execKey "5" { play "mouse_click"; scriptMenuResponse "springfield_mp" ; close weapon_american; }
+
+		execKeyInt 32 { play "mouse_click"; close weapon_american; open main; } // space
+	}
+}

--- a/20240930_codextended/ui_mp/scriptmenus/weapon_british.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/weapon_british.menu
@@ -1,0 +1,81 @@
+#include "ui_mp/menudef.h"
+#include "ui_mp/macros.h"
+
+#define HIDE_ALL hide enfield; hide sten; hide bren; hide springfield;
+
+{
+	menuDef
+	{
+		name			"weapon_british"
+		rect			0 0 640 480
+		focuscolor		1 1 1 1
+		style			WINDOW_STYLE_EMPTY
+		//blurWorld		5.0
+		onOpen
+		{
+			CLOSE_SUBMENUS;
+			open weapon_british_keys;
+
+			// Make sure cursor is enable (in case of spectator menu fails)
+			setDvar cl_bypassMouseInput "0" // enable cursor movement
+
+		}
+		onClose
+		{
+			CLOSE_SUBMENUS;
+			close matchinfo;
+		}
+		onEsc
+		{
+			HIDE_ALL
+			close weapon_british;
+			close matchinfo;
+			close weapon_british_keys;
+		}
+
+
+		// Background
+		DRAW_MAP_BACKGROUND_IF_BLACKOUT
+		DRAW_BLUISH_BACKGROUND
+		DRAW_GRADIENT_LEFT_TO_RIGHT
+		DRAW_BARS
+
+		// Header
+		ITEM_TEXT_HEADING("@MPMENU_WEAPON")
+
+
+		// MENU CHOICES
+		ITEM_WEAPON(ORIGIN_CHOICE1, "button_enfield", "enfield_mp", "@MPMENU_1_LEEENFIELD", "ui_allow_enfield", "enfield", show enfield;, scriptMenuResponse "enfield_mp", grenadeimage, "boltaction";)
+
+		ITEM_WEAPON(ORIGIN_CHOICE2, "button_sten", "sten_mp", "@MPMENU_2_STEN", "ui_allow_m1garand", "sten" , show sten;, scriptMenuResponse "sten_mp", grenadeimage, "smg")
+
+		ITEM_WEAPON(ORIGIN_CHOICE3, "button_bren", "bren_mp", "@MPMENU_3_BREN_LMG", "ui_allow_bren", "bren" , show bren;, scriptMenuResponse "bren_mp", grenadeimage, "mg")
+
+		ITEM_WEAPON(ORIGIN_CHOICE4, "button_springfield", "springfield_mp", "@MPMENU_4_SPRINGFIELD", "ui_allow_springfield", "springfield" , show springfield;, scriptMenuResponse "springfield_mp", grenadeimage, "sniper")
+
+
+
+		// Close
+		ITEM_BAR_BOTTOM_BUTTON("^9[ESC]^7 Close",	40, 70, close weapon_british;)
+		// Main menu
+		ITEM_BAR_BOTTOM_BUTTON("^9[SPACE]^7 Main Menu",	135, 120, close weapon_british; open main;)
+	}
+
+
+	// Key choices has to be in different menu if we are using submenus
+	// This keys is opened as last and will be in focus - so keys from this submenu will be accepted
+	menuDef
+	{
+		name			"weapon_british_keys"
+		rect			0 0 1 1
+		focuscolor		GLOBAL_FOCUSED_COLOR
+		style			WINDOW_STYLE_EMPTY
+
+		execKey "1" { play "mouse_click"; scriptMenuResponse "enfield_mp"; close weapon_british }
+		execKey "2" { play "mouse_click"; scriptMenuResponse "sten_mp"; close weapon_british }
+		execKey "3" { play "mouse_click"; scriptMenuResponse "bren_mp"; close weapon_british }
+		execKey "4" { play "mouse_click"; scriptMenuResponse "springfield_mp"; close weapon_british }
+
+		execKeyInt 32 { play "mouse_click"; close weapon_british; open main; } // space
+	}
+}

--- a/20240930_codextended/ui_mp/scriptmenus/weapon_british.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/weapon_british.menu
@@ -14,6 +14,7 @@
 		onOpen
 		{
 			CLOSE_SUBMENUS;
+			exec "set cg_drawstatus 0";
 			open weapon_british_keys;
 
 			// Make sure cursor is enable (in case of spectator menu fails)
@@ -24,6 +25,7 @@
 		{
 			CLOSE_SUBMENUS;
 			close matchinfo;
+			exec "set cg_drawstatus 1";
 		}
 		onEsc
 		{
@@ -31,6 +33,7 @@
 			close weapon_british;
 			close matchinfo;
 			close weapon_british_keys;
+			exec "set cg_drawstatus 1";
 		}
 
 

--- a/20240930_codextended/ui_mp/scriptmenus/weapon_german.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/weapon_german.menu
@@ -14,6 +14,7 @@
 		onOpen
 		{
 			CLOSE_SUBMENUS;
+			exec "set cg_drawstatus 0";
 			open weapon_german_keys;
 
 			// Make sure cursor is enable (in case of spectator menu fails)
@@ -24,6 +25,7 @@
 		{
 			CLOSE_SUBMENUS;
 			close matchinfo;
+			exec "set cg_drawstatus 1";
 		}
 		onEsc
 		{
@@ -31,6 +33,7 @@
 			close weapon_german;
 			close matchinfo;
 			close weapon_german_keys;
+			exec "set cg_drawstatus 1";
 		}
 
 		// Background

--- a/20240930_codextended/ui_mp/scriptmenus/weapon_german.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/weapon_german.menu
@@ -1,0 +1,80 @@
+#include "ui_mp/menudef.h"
+#include "ui_mp/macros.h"
+
+#define HIDE_ALL hide kar98; hide mp40; hide mp44; hide kar98scoped;
+
+{
+	menuDef
+	{
+		name			"weapon_german"
+		rect			0 0 640 480
+		focuscolor		1 1 1 1
+		style			WINDOW_STYLE_EMPTY
+		//blurWorld		5.0
+		onOpen
+		{
+			CLOSE_SUBMENUS;
+			open weapon_german_keys;
+
+			// Make sure cursor is enable (in case of spectator menu fails)
+			setDvar cl_bypassMouseInput "0" // enable cursor movement
+
+		}
+		onClose
+		{
+			CLOSE_SUBMENUS;
+			close matchinfo;
+		}
+		onEsc
+		{
+			HIDE_ALL
+			close weapon_german;
+			close matchinfo;
+			close weapon_german_keys;
+		}
+
+		// Background
+		DRAW_MAP_BACKGROUND_IF_BLACKOUT
+		DRAW_BLUISH_BACKGROUND
+		DRAW_GRADIENT_LEFT_TO_RIGHT
+		DRAW_BARS
+
+		// Header
+		ITEM_TEXT_HEADING("@MPMENU_WEAPON")
+
+
+		// MENU CHOICES
+		ITEM_WEAPON(ORIGIN_CHOICE1, "button_kar98k", "kar98k_mp", "@MPMENU_1_KAR98K", "ui_allow_kar98k", "kar98", show kar98;, scriptMenuResponse "kar98k_mp", grenadeimage, "boltaction")
+
+		ITEM_WEAPON(ORIGIN_CHOICE2, "button_mp40", "mp40_mp", "@MPMENU_2_MP40", "ui_allow_mp40", "mp40" , show mp40;, scriptMenuResponse "mp40_mp", grenadeimage, "smg")
+
+		ITEM_WEAPON(ORIGIN_CHOICE3, "button_mp44", "mp44_mp", "@MPMENU_3_MP44", "ui_allow_mp44", "mp44" , show mp44;, scriptMenuResponse "mp44_mp", grenadeimage, "mg")
+
+		ITEM_WEAPON(ORIGIN_CHOICE4, "button_kar98ksniper", "kar98k_sniper_mp", "@MPMENU_4_SCOPED_KAR98K", "ui_allow_kar98ksniper", "kar98scoped" , show kar98scoped;, scriptMenuResponse "kar98k_sniper_mp", grenadeimage, "sniper")
+
+
+
+		// Close
+		ITEM_BAR_BOTTOM_BUTTON("^9[ESC]^7 Close",	40, 70, close weapon_german;)
+		// Main menu
+		ITEM_BAR_BOTTOM_BUTTON("^9[SPACE]^7 Main Menu",	135, 120, close weapon_german; open main;)
+	}
+
+
+	// Key choices has to be in different menu if we are using submenus
+	// This keys is opened as last and will be in focus - so keys from this submenu will be accepted
+	menuDef
+	{
+		name			"weapon_german_keys"
+		rect			0 0 1 1
+		focuscolor		GLOBAL_FOCUSED_COLOR
+		style			WINDOW_STYLE_EMPTY
+
+		execKey "1" { play "mouse_click"; scriptMenuResponse "kar98k_mp"; close weapon_german }
+		execKey "2" { play "mouse_click"; scriptMenuResponse "mp40_mp"; close weapon_german }
+		execKey "3" { play "mouse_click"; scriptMenuResponse "mp44_mp"; close weapon_german }
+		execKey "4" { play "mouse_click"; scriptMenuResponse "kar98k_sniper_mp"; close weapon_german }
+
+		execKeyInt 32 { play "mouse_click"; close weapon_german; open main; } // space
+	}
+}

--- a/20240930_codextended/ui_mp/scriptmenus/weapon_russian.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/weapon_russian.menu
@@ -1,0 +1,77 @@
+#include "ui_mp/menudef.h"
+#include "ui_mp/macros.h"
+
+#define HIDE_ALL hide nagant; hide ppsh; hide nagantscoped;
+
+{
+	menuDef
+	{
+		name			"weapon_russian"
+		rect			0 0 640 480
+		focuscolor		1 1 1 1
+		style			WINDOW_STYLE_EMPTY
+		//blurWorld		5.0
+		onOpen
+		{
+			CLOSE_SUBMENUS;
+			open weapon_russian_keys;
+
+			// Make sure cursor is enable (in case of spectator menu fails)
+			setDvar cl_bypassMouseInput "0" // enable cursor movement
+		}
+		onClose
+		{
+			CLOSE_SUBMENUS;
+			close matchinfo;
+		}
+		onEsc
+		{
+			HIDE_ALL
+			close weapon_russian;
+			close matchinfo;
+			close weapon_russian_keys;
+		}
+
+
+		// Background
+		DRAW_MAP_BACKGROUND_IF_BLACKOUT
+		DRAW_BLUISH_BACKGROUND
+		DRAW_GRADIENT_LEFT_TO_RIGHT
+		DRAW_BARS
+
+		// Header
+		ITEM_TEXT_HEADING("@MPMENU_WEAPON")
+
+
+		// MENU CHOICES
+		ITEM_WEAPON(ORIGIN_CHOICE1, "button_nagant", "mosin_nagant_mp", "@MPMENU_1_MOSINNAGANT", "ui_allow_nagant", "nagant", show nagant;, scriptMenuResponse "mosin_nagant_mp", grenadeimage, "boltaction";)
+
+		ITEM_WEAPON(ORIGIN_CHOICE2, "button_ppsh", "ppsh_mp", "@MPMENU_2_PPSH", "ui_allow_ppsh", "ppsh" , show ppsh;, scriptMenuResponse "ppsh_mp", grenadeimage, "mg")
+
+		ITEM_WEAPON(ORIGIN_CHOICE3, "button_nagantnsiper", "mosin_nagant_sniper_mp", "@MPMENU_3_SCOPED_MOSINNAGANT", "ui_allow_nagantsniper", "nagantscoped" , show nagantscoped;, scriptMenuResponse "mosin_nagant_sniper_mp", grenadeimage, "sniper")
+
+
+
+		// Close
+		ITEM_BAR_BOTTOM_BUTTON("^9[ESC]^7 Close",	40, 70, close weapon_russian;)
+		// Main menu
+		ITEM_BAR_BOTTOM_BUTTON("^9[SPACE]^7 Main Menu",	135, 120, close weapon_russian; open main;)
+	}
+
+
+	// Key choices has to be in different menu if we are using submenus
+	// This keys is opened as last and will be in focus - so keys from this submenu will be accepted
+	menuDef
+	{
+		name			"weapon_russian_keys"
+		rect			0 0 1 1
+		focuscolor		GLOBAL_FOCUSED_COLOR
+		style			WINDOW_STYLE_EMPTY
+
+		execKey "1" { play "mouse_click"; scriptMenuResponse "mosin_nagant_mp"; close weapon_russian }
+		execKey "2" { play "mouse_click"; scriptMenuResponse "ppsh_mp"; close weapon_russian }
+		execKey "3" { play "mouse_click"; scriptMenuResponse "mosin_nagant_sniper_mp"; close weapon_russian }
+
+		execKeyInt 32 { play "mouse_click"; close weapon_german; open main; } // space
+	}
+}

--- a/20240930_codextended/ui_mp/scriptmenus/weapon_russian.menu
+++ b/20240930_codextended/ui_mp/scriptmenus/weapon_russian.menu
@@ -14,6 +14,7 @@
 		onOpen
 		{
 			CLOSE_SUBMENUS;
+			exec "set cg_drawstatus 0";
 			open weapon_russian_keys;
 
 			// Make sure cursor is enable (in case of spectator menu fails)
@@ -23,6 +24,7 @@
 		{
 			CLOSE_SUBMENUS;
 			close matchinfo;
+			exec "set cg_drawstatus 1";
 		}
 		onEsc
 		{
@@ -30,6 +32,7 @@
 			close weapon_russian;
 			close matchinfo;
 			close weapon_russian_keys;
+			exec "set cg_drawstatus 1";
 		}
 
 


### PR DESCRIPTION
- cod2 weapon menu implemented Known issues:
	- Can't choose weapon by pressing the numbers on the keyboard like in the team menu
	- hideCvar { "" } won't hide the 'Used by' text when a weapon is not chosen
- Springfield on British fixed
- amount of nades for rifles fixed
- ui fixes:
	- Bottom buttons in menu are in the correct color
	- American team name fixed (Russian --> American)